### PR TITLE
feat(localization): allow strings to be localized from the main bundle

### DIFF
--- a/Sources/SCSDKCameraKitReferenceUI/Localization/LocalizedString.swift
+++ b/Sources/SCSDKCameraKitReferenceUI/Localization/LocalizedString.swift
@@ -45,7 +45,7 @@ public func CameraKitLocalizedString(
     table: String? = nil
 ) -> String {
     let resolvedBundle = bundle ?? bestBundle(forPreferredLanguages: preferredLanguages)
-    let mainBundle = Bundle.main
+    let mainBundle = bundle ?? Bundle.main
     let fallbackBundle = bestBundle(forPreferredLanguages: ["en-US"])
     let mainBundleResolvedString = mainBundle.localizedString(forKey: key, value: nil, table: table)
     let resolvedString = resolvedBundle.localizedString(forKey: key, value: nil, table: table)


### PR DESCRIPTION
While implementing the CameraKitReferenceUI in our project we stumbled across an issue with localization. The app we are working on needs to support multiple languages and opening the Main Bundle to resolve the localized string would solve our issue giving us the opportunity to contribute the keys directly from our project.